### PR TITLE
changes to krnlstrlen and krnldiffstr

### DIFF
--- a/base/feral/krnl/kernel_main.c
+++ b/base/feral/krnl/kernel_main.c
@@ -50,7 +50,7 @@ int krnldiffstr(char* string, char* string1)
 	int index = 0;
 	char c  = string[0];
 	char c1 = string1[0];
-	while (c == c1)
+	while (c == c1 || (c != '\0' || c1 != '\0'))
 	{
 		index = index++;
 		c     = string[index];
@@ -62,7 +62,7 @@ int krnldiffstr(char* string, char* string1)
 int krnlstrlen(char* string)
 {
 	int len = 0;
-	while (string[len] != 0)
+	while (string[len] != '\0')
 	{
 		len = len++;
 	}


### PR DESCRIPTION
krnldiffstr could reach out of bounds as (assuming the string is null-terminated) there's no check whether the character being evaluated is null, therefore if the character after the null on `c` were to be the same as the character after the null on `c2` the `index` would be incorrect.

also when comparing characters to nil, use `'\0'` instead of `0`